### PR TITLE
Default alloc_ration/alloc_align should be 1/(multiple of page size)

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -96,8 +96,8 @@ int get_options(int argc, char **argv,
 	ASSERT(mapfile); *mapfile = NULL;
 	ASSERT(output); *output = NULL;
     ASSERT(prelinkmap); *prelinkmap = NULL;
-    ASSERT(alloc_ratio); *alloc_ratio = 4;
-    ASSERT(alloc_align); *alloc_align = 0x200000; // 2MB
+    ASSERT(alloc_ratio); *alloc_ratio = 1;
+    ASSERT(alloc_align); *alloc_align = 0x10000; // 64KB
     int dirs_size = 0;
     int defaults_size = 0;
 


### PR DESCRIPTION
The larger value 4/2MB is for creating the map only; When calculating the size required by a library, we need parameters to be as small as possible.
